### PR TITLE
Bugfix: Pirate raid event

### DIFF
--- a/confederation at crisis/events/character_flavor_events.txt
+++ b/confederation at crisis/events/character_flavor_events.txt
@@ -665,7 +665,7 @@ character_event = {
 	
 	option = {
 		name = "EVTOPTCONFIRM"
-		transfer_scaled_wealth = { who = FROM value = 1.0 }
+		transfer_scaled_wealth = { to = FROM value = 1.0 }
 	}
 }
 
@@ -679,7 +679,7 @@ character_event = {
 	
 	option = {
 		name = "EVTOPTCONFIRM"
-		transfer_scaled_wealth = { who = FROM value = 1.0 }
+		transfer_scaled_wealth = { to = FROM value = 1.0 }
 		imprison = FROM
 	}
 }


### PR DESCRIPTION
Fixed a bug that prevented a flavor event from properly rewarding pirates with stolen valuables.