### PR TITLE
Handful of minor fixes

### DIFF
--- a/confederation at crisis/common/government_flavor/00_government_flavor.txt
+++ b/confederation at crisis/common/government_flavor/00_government_flavor.txt
@@ -40,7 +40,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_hivemind_government
-	graphics = GFX_gov_hivemind_government
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -51,7 +51,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_system_lords
-	graphics = GFX_gov_system_lords
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -62,7 +62,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_abs_military_republic
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -85,7 +85,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_military_republic
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -110,7 +110,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_abs_military_monarchy
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -133,7 +133,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_military_monarchy
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -157,7 +157,7 @@ government_flavor = {
 }
 government_flavor = {
 	name = gov_abs_military_directorate
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -180,7 +180,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_military_directorate
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -204,7 +204,7 @@ government_flavor = {
 }
 government_flavor = {
 	name = gov_abs_administrative_republic
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -227,7 +227,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_administrative_republic
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -251,7 +251,7 @@ government_flavor = {
 }
 government_flavor = {
 	name = gov_abs_administrative_monarchy
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -274,7 +274,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_administrative_monarchy
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -298,7 +298,7 @@ government_flavor = {
 }
 government_flavor = {
 	name = gov_abs_administrative_directorate
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -321,7 +321,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_administrative_directorate
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -345,7 +345,7 @@ government_flavor = {
 }
 government_flavor = {
 	name = gov_abs_corporate_republic
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -368,7 +368,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_corporate_republic
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -392,7 +392,7 @@ government_flavor = {
 }
 government_flavor = {
 	name = gov_abs_corporate_monarchy
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -415,7 +415,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_corporate_monarchy
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -439,7 +439,7 @@ government_flavor = {
 }
 government_flavor = {
 	name = gov_abs_corporate_directorate
-	graphics = GFX_abs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -462,7 +462,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_nnabs_corporate_directorate
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -487,7 +487,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_military_command_flavor
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -498,7 +498,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_merchant_republic_government_flavor
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -509,7 +509,7 @@ government_flavor = {
 
 government_flavor = {
 	name = gov_colonial_government_flavor
-	graphics = GFX_nnabs_government_type
+	graphics = GFX_evt_govplaceholder
 	priority = 1
 	trigger = {
 		OR = {
@@ -517,6 +517,23 @@ government_flavor = {
 		}
 	}
 }
+
+#####################################
+# Special Flavor Names (priority 2) #
+#####################################
+
+government_flavor = {
+	name = gov_terran_megacorp
+	graphics = GFX_evt_govplaceholder
+	priority = 2
+	trigger = {
+		is_patrician = yes
+		higher_tier_than = BARON
+		liege = { tier = EMPEROR }
+		culture_group = terran_group
+	}
+}
+
 #####################################
 # Special Flavor Names (priority 4) #
 #####################################

--- a/confederation at crisis/common/scripted_effects/crisis_injury_effects.txt
+++ b/confederation at crisis/common/scripted_effects/crisis_injury_effects.txt
@@ -81,15 +81,11 @@ inflict_minor_injury_effect = {
 inflict_moderate_injury_effect = {
 	if = {
 		limit = {
-			trait = maimed
 			OR = {
 				trait = one_eyed
 				trait = blinded
-				NOT = { has_dlc = "Reapers" }
-			}
-			OR = {
+				trait = maimed
 				trait = disfigured
-				NOT = { has_dlc = "Reapers" }
 			}
 		}
 		inflict_major_injury_effect = yes
@@ -101,7 +97,10 @@ inflict_moderate_injury_effect = {
 				15 = {
 					modifier = {
 						factor = 0
-						trait = maimed
+						OR = {
+							trait = maimed
+							has_dlc = "Reapers"
+						}
 					}
 					add_trait = maimed
 					hidden_tooltip = { character_event = { id = 38281 } }

--- a/confederation at crisis/common/traits/00_traits.txt
+++ b/confederation at crisis/common/traits/00_traits.txt
@@ -1338,7 +1338,7 @@ celibate = {
 	opposite_opinion = -10
 	same_opinion = 10
 	
-	ai_zeal = 10
+	ai_zeal = 30
 
 	monthly_character_piety = 0.25
 	male_compliment = COMPL_VIRTUOUS
@@ -1508,7 +1508,7 @@ athlete = {
 	
 	martial = 2
 	health = 1
-	combat_rating = 5
+	combat_rating = 15
 	
 	same_opinion = 10
 }
@@ -2046,133 +2046,8 @@ cruel = {
 }
 
 #Leadership traits
-light_foot_leader = {
-	leader = yes
-	
-	command_modifier = {
-		light_infantry = 0.2
-	}
-}
-
-heavy_infantry_leader = {
-	leader = yes
-	
-	command_modifier = {
-		heavy_infantry = 0.2
-	}
-}
-
-cavalry_leader = {
-	leader = yes
-	
-	command_modifier = {
-		cavalry = 0.2
-	}
-}
-
-inspiring_leader = {
-	leader = yes
-	
-	command_modifier = {
-		morale_offence = 0.15
-		morale_defence = 0.15
-	}
-}
-
-trickster = {
-	leader = yes
-	
-	command_modifier = {
-		random = 0.3
-	}
-}
-
-organizer = {
-	leader = yes
-	
-	command_modifier = {
-		speed = 0.1
-		retreat = 0.1
-	}
-}
-
-defensive_leader = {
-	leader = yes
-	
-	command_modifier = {
-		defence = 0.25
-		damage = -0.1
-	}
-}
-
-# Renamed to "Direct Leader"
-experimenter = {
-	leader = yes
-	
-	command_modifier = {
-		center = 0.2
-	}
-}
-
-flanker = {
-	leader = yes
-	
-	command_modifier = {
-		flank = 0.2
-	}
-}
-
-aggressive_leader = {
-	leader = yes
-	
-	command_modifier = {
-		pursue = 0.25
-		damage = 0.1
-		defence = -0.1
-	}
-}
-
-siege_leader = {
-	leader = yes
-	
-	command_modifier = {
-		siege = 0.4
-	}
-}
-################################################
-# LIFESTYLE - Events - only 1 lifestyle (adult)
-################################################
-athlete = {
-	lifestyle= yes
-	cached = yes
-	martial = 3 
-	combat_rating = 30
-	same_opinion = 20
-}
-artist = {
-	lifestyle = yes
-	cached = yes
-	diplomacy = 3
-	same_opinion = 20
-}
-intellectual = {
-	lifestyle = yes
-	cached = yes
-	learning = 3
-	same_opinion = 20
-}
-gardener = {
-	lifestyle = yes
-	cached = yes
-	stewardship = 3
-	same_opinion = 20
-}
-mystic = {
-	lifestyle = yes
-	cached = yes
-	intrigue = 3
-	same_opinion = 20
-}
+#Command traits are now in crisis_traits, do not restore these
+#Removed redundant set of lifestyle traits that was here previously
 
 #################################################################
 # PERSONALITY - Events, should happen more often during childhood
@@ -2409,7 +2284,7 @@ radical = {
 	same_opinion_if_same_religion = 25
 	opposite_opinion = -20
 	
-	ai_zeal = 30
+	ai_zeal = 100
 	ai_honor = 10
 	
 	male_insult = INSULT_FANATIC
@@ -2436,7 +2311,7 @@ pragmatic = {
 	same_opinion = 10
 	opposite_opinion = -20
 	
-	ai_zeal = -30
+	ai_zeal = -100
 	ai_rationality = 10
 	
 	male_compliment_adj = COMPL_WRY

--- a/confederation at crisis/common/traits/crisis_traits.txt
+++ b/confederation at crisis/common/traits/crisis_traits.txt
@@ -44,20 +44,20 @@ target = {
 # The two factions that form in a constitutional crisis, handled using traits for now because of the complexity
 pro_ruler = {
 	opposites = { anti_ruler }
-
+	
 	cached = yes
 	customizer = no
-
+	
 	liege_opinion = 20
 	opposite_opinion = -25
 }
 
 anti_ruler = {
 	opposites = { pro_ruler }
-
+	
 	cached = yes
 	customizer = no
-
+	
 	liege_opinion = -20
 	opposite_opinion = -25
 }
@@ -98,7 +98,7 @@ marine_colonel = {
 		warship_captain
 	}
 	command_modifier = {
-		siege = 0.5
+		siege = 0.25
 	}
 	combat_rating = 30
 }
@@ -106,25 +106,24 @@ marine_colonel = {
 # Additional Military Traits
 inspiring_leader = {
 	leader = yes
-
+	
 	command_modifier = {
-		morale_defence = 0.1
-		center = 0.1
+		morale_defence = 0.15
+		morale_offence = 0.15
 	}
 }
 
 trickster = {
 	leader = yes
-
+	
 	command_modifier = {
-		morale_offence = 0.1
-		defence = -0.2
+		random = 0.3
 	}
 }
 
 organizer = {
 	leader = yes
-
+	
 	command_modifier = {
 		speed = 0.2
 		retreat = 0.1
@@ -133,24 +132,25 @@ organizer = {
 
 defensive_leader = {
 	leader = yes
-
+	
 	command_modifier = {
 		defence = 0.1
 		damage = -0.2
 	}
 }
 
-experimenter = {
+experimenter = { #Actually Direct Leader
 	leader = yes
-
+	
 	command_modifier = {
-		random = 0.3
+		center = 0.2
+		flank = -0.2
 	}
 }
 
 flanker = {
 	leader = yes
-
+	
 	command_modifier = {
 		flank = 0.2
 		center = -0.2
@@ -159,7 +159,7 @@ flanker = {
 
 aggressive_leader = {
 	leader = yes
-
+	
 	command_modifier = {
 		pursue = 0.2
 		damage = 0.1
@@ -167,9 +167,9 @@ aggressive_leader = {
 	}
 }
 
-blockade_leader = {
+siege_leader = {
 	leader = yes
-
+	
 	command_modifier = {
 		siege = 0.4
 	}
@@ -184,90 +184,90 @@ not_ready_to_marry = {
 has_cosmic_radiation = {
 	is_epidemic = yes
 	is_illness = yes
-
+	
 	diplomacy_penalty = -2
 	martial_penalty = -3
 	stewardship_penalty = -2
 	intrigue_penalty = -3
 	learning_penalty = -2
-
+	
 	health_penalty = -6
-
+	
 	fertility_penalty = -0.50
-
+	
 	combat_rating = -100
 
 	male_insult_adj = INSULT_DECAYING
 	female_insult_adj = INSULT_DECAYING
 	child_insult_adj = INSULT_SMELLY
-
+	
 	succession_gfx = yes
 }
 has_flu = {
 	is_epidemic = yes
 	is_illness = yes
-
+	
 	health = -2
-
+	
 	customizer = no
 }
 has_flu = {
 	is_epidemic = yes
 	is_illness = yes
-
+	
 	health = -2
-
+	
 	customizer = no
 }
 has_clarkes_disease = {
 	is_epidemic = yes
 	is_illness = yes
-
+	
 	health = -1
 	diplomacy = -1
 	martial = -1
 	intrigue = -1
 	stewardship = -1
 	learning = -1
-
+	
 	customizer = no
 }
 has_cybernetic_virus = {
 	potential = { trait = dni }
 	is_epidemic = yes
 	is_illness = yes
-
+	
 	diplomacy = -5
 	martial = -5
 	intrigue = -5
 	stewardship = -5
 	learning = -5
-
+	
 	ai_rationality = -30
-
+	
 	customizer = no
 }
 has_edemite_fever = {
 	is_epidemic = yes
 	is_illness = yes
-
+	
 	health = -10
-
+	
 	customizer = no
 }
 has_brain_slug = {
 	is_epidemic = yes
 	is_illness = yes
-
+	
 	ambition_opinion = -25
-
+	
 	martial = -3
 	intrigue = -3
-
+	
 	ai_rationality = -30
 	ai_zeal = 30
 	ai_ambition = 30
-
+	
 	customizer = no
 }
 
@@ -276,30 +276,30 @@ has_great_depression = {
 	potential = { religion_group = political_terran_group }
 	is_epidemic = yes
 	is_illness = yes
-
+	
 	diplomacy = -5
-	martial = -5
+	martial = -5 
 	intrigue = -5
 	stewardship = -5
 	learning = -5
 	health = -0.5
-
+	
 	ai_rationality = -45
 	ai_zeal = 25
 	ai_honor = -15
-	ai_ambition = 35
-
+	ai_ambition = 35 
+	
 	customizer = no
 }
 
 # Mental Illness
 has_ptsd = {
 	is_health = yes
-
+	
 	# Somewhat event driven
 	martial = -1
 	intrigue = -1
-
+	
 	ruler_designer_cost = -20
 }
 
@@ -333,7 +333,7 @@ spice_addict = {
 		full_cybernetic_conversion
 	}
 	is_health = yes
-
+	
 	# Largely event-driven
 	health = -1
 	general_opinion = -10
@@ -345,7 +345,7 @@ former_spice_addict = {
 		full_cybernetic_conversion
 	}
 	is_health = yes
-
+	
 	health = -1
 	general_opinion = -10
 }
@@ -353,23 +353,23 @@ warlord = {
 	martial = 2
 	stewardship = 1
 	diplomacy = -2
-
+	
 	command_modifier = {
 		damage = 0.01
 		morale_offence = 0.01
 		defence = -0.01
 	}
-
+	
 	general_opinion = -5
 	vassal_opinion = 5
-
+	
 	ai_ambition = 100
 	ai_zeal = 25
 	ai_honor = -10
 	ai_greed = 15
-
+	
 	customizer = no
 	random = no
-
+	
 	religious_group_opinion = -5
 }

--- a/confederation at crisis/decisions/employment_decisions.txt
+++ b/confederation at crisis/decisions/employment_decisions.txt
@@ -1,8 +1,32 @@
 decisions = {
+	toggle_employment = {
+		only_playable = yes
+		potential = {
+			ai = no
+		}
+		effect = {
+			if = {
+				limit = {
+					NOT = { has_character_flag = toggle_employment }
+				}
+				set_character_flag = toggle_employment
+				break = yes
+			}
+			clr_character_flag = toggle_employment
+		}
+		ai_will_do = {
+			factor = 0
+		}
+	}
 	employ_diplomat_decision = {
 		only_playable = yes
 		ai_check_interval = 30
-		potential = { always = yes }
+		potential = { 
+			OR = {
+				ai = yes
+				has_character_flag = toggle_employment
+			}
+		}
 		allow = {
 			scaled_wealth = 0.25
 			NOT = { has_character_modifier = in_seclusion }
@@ -277,7 +301,12 @@ decisions = {
 	employ_commander_decision = {
 		only_playable = yes
 		ai_check_interval = 30
-		potential = { always = yes }
+		potential = { 
+			OR = {
+				ai = yes
+				has_character_flag = toggle_employment
+			}
+		}
 		allow = {
 			prestige = 25
 			scaled_wealth = 0.25
@@ -323,7 +352,12 @@ decisions = {
 	employ_steward_decision = {
 		only_playable = yes
 		ai_check_interval = 30
-		potential = { always = yes }
+		potential = { 
+			OR = {
+				ai = yes
+				has_character_flag = toggle_employment
+			}
+		}
 		allow = {
 			scaled_wealth = 0.25
 			NOT = { has_character_modifier = in_seclusion }
@@ -598,7 +632,12 @@ decisions = {
 	employ_spymaster_decision = {
 		only_playable = yes
 		ai_check_interval = 30
-		potential = { always = yes }
+		potential = { 
+			OR = {
+				ai = yes
+				has_character_flag = toggle_employment
+			}
+		}
 		allow = {
 			scaled_wealth = 0.25
 			NOT = { has_character_modifier = in_seclusion }
@@ -873,7 +912,12 @@ decisions = {
 	employ_scholar_decision = {
 		only_playable = yes
 		ai_check_interval = 30
-		potential = { always = yes }
+		potential = { 
+			OR = {
+				ai = yes
+				has_character_flag = toggle_employment
+			}
+		}
 		allow = {
 			piety = 25
 			scaled_wealth = 0.25
@@ -1151,7 +1195,12 @@ decisions = {
 		only_playable = yes
 		ai_check_interval = 12
 
-		potential = { always = yes }
+		potential = { 
+			OR = {
+				ai = yes
+				has_character_flag = toggle_employment
+			}
+		}
 		allow = {
 			scaled_wealth = 0.20
 			NOT = { has_character_modifier = in_seclusion }
@@ -1283,7 +1332,12 @@ decisions = {
 		only_playable = yes
 		ai_check_interval = 12
 
-		potential = { always = yes }
+		potential = { 
+			OR = {
+				ai = yes
+				has_character_flag = toggle_employment
+			}
+		}
 		allow = {
 			scaled_wealth = 0.20
 			NOT = { has_character_modifier = in_seclusion }

--- a/confederation at crisis/events/job_lord_spiritual.txt
+++ b/confederation at crisis/events/job_lord_spiritual.txt
@@ -34,10 +34,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		NOT = { location = { religion = ROOT } }
 		location = {
 			owner = { same_realm = ROOT }
@@ -55,6 +58,14 @@ character_event = {
 			}
 		}
 		modifier = {
+			factor = 0.6
+			has_religion_feature = religion_proselytizing
+		}
+		modifier = {
+			factor = 2.5
+			has_religion_feature = religion_cosmopolitan
+		}
+		modifier = {
 			factor = 0.75
 			liege = {
 				has_artifact = finger_of_st_john
@@ -62,64 +73,42 @@ character_event = {
 		}
 		modifier = {
 			factor = 0.75
+			has_job_action = action_inquisition
 			location = { culture_group = ROOT }
 		}
 		modifier = {
 			factor = 0.75
+			has_job_action = action_inquisition
 			location = { culture = ROOT }
 		}
 		modifier = {
 			factor = 0.5
+			has_job_action = action_inquisition
 			location = { religion_group = ROOT }
 		}
 		modifier = {
 			factor = 0.75
+			has_job_action = action_inquisition
 			location = { has_province_modifier = depopulated_1 }
 		}
 		modifier = {
 			factor = 0.50
+			has_job_action = action_inquisition
 			location = { has_province_modifier = depopulated_2 }
 		}
 		modifier = {
 			factor = 0.25
+			has_job_action = action_inquisition
 			location = { has_province_modifier = depopulated_3 }
 		}
 		modifier = {
 			factor = 3.0
+			has_job_action = action_inquisition
 			location = { is_hard_to_convert = yes }
 		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+
+		job_event_mtth_modifier_learning_score = yes
+
 		modifier = {
 			factor = 3.0
 			NOT = { religion_authority = 0.1 }
@@ -163,22 +152,102 @@ character_event = {
 				society_rank >= 4
 			}
 		}
+		#Bloodlines
+		modifier = {
+			factor = 0.75
+			liege = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_better_inquisition
+					bloodline_is_active_for = PREV
+				}
+			}
+		}
+		modifier = {
+			factor = 0.75
+			#If chaplain is also your relative.
+			any_owned_bloodline = {
+				has_bloodline_flag = bloodline_better_inquisition
+				bloodline_is_active_for = PREV
+			}
+		}
+		modifier = {
+			factor = 0.6
+			NOT = {
+				liege = {
+					any_owned_bloodline = {
+						has_bloodline_flag = inquisitional_bloodline
+						bloodline_is_active_for = PREV
+					}
+				}
+			}
+			liege = {
+		    	any_owned_bloodline = {
+    				has_bloodline_flag = inquisitional_saintly_bloodline
+    				founder = {
+    					religion = ROOT
+    				}
+    			}
+    		}
+		}
+		modifier = {
+			factor = 0.4
+			liege = {
+				any_owned_bloodline = {
+					has_bloodline_flag = inquisitional_bloodline
+					bloodline_is_active_for = PREV
+				}
+			}
+		}
+		
+		modifier = {
+			factor = 0.6
+			religion = hindu
+	    	any_owned_bloodline = {
+    			has_bloodline_flag = bloodline_faster_hindu
+    		}
+		}
+
+		# Effect of wonder upgrades
+		modifier = {
+			factor = 0.6
+			liege = {
+				any_realm_wonder_upgrade = {
+					has_wonder_upgrade_flag = religion_conversion_faster
+					is_active = yes
+					wonder = {
+						original_wonder_owner = {
+							religion_group = PREVPREVPREV
+						}
+					}
+				}
+			}
+		}
 		
 		# Hindus and Buddhists have a hard time converting other Indian religions
 		modifier = {
 			factor = 3.0
+			has_job_action = action_inquisition
 			OR = {
 				religion = hindu
 				religion = buddhist
 			}
 			location = {
 				religion_group = indian_group
+				NOT = {
+					religion = taoist
+				}
 			}
 		}
-		# Jains have a hard time converting ALL non-pagans
+		# Jains, Taoists and Bön have a hard time converting ALL non-pagans
 		modifier = {
 			factor = 3.0
-			religion = jain
+			has_job_action = action_inquisition
+			OR = {
+				religion = jain
+				religion = taoist
+				religion = bon
+				religion = bon_reformed
+			}
 			location = {
 				NOT = { religion_group = pagan_group }
 			}
@@ -186,6 +255,7 @@ character_event = {
 		
 		modifier = {
 			factor = 3.0
+			has_job_action = action_inquisition
 			religion_group = pagan_group
 			is_reformed_religion = no
 			location = {
@@ -197,16 +267,19 @@ character_event = {
 		}
 		modifier = {
 			factor = 1.5
+			has_job_action = action_inquisition
 			location = { is_heresy_of = ROOT }
 		}
 		modifier = {
 			factor = 0.75
+			has_job_action = action_inquisition
 			location = {
 				has_province_modifier = force_converting
 			}
 		}
 		modifier = {
 			factor = 3.0
+			has_job_action = action_inquisition
 			location = {
 				has_province_modifier = heretic_stronghold
 			}
@@ -218,6 +291,7 @@ character_event = {
 				value = slower
 			}
 		}
+
 	}
 
 	option = {
@@ -260,6 +334,14 @@ letter_event = {
 	option = {
 		name = "EVTOPTA20000"
 		piety = 15
+		hidden_tooltip = {
+			if = {
+				limit = {
+					has_ambition = obj_strengthen_religion
+				}
+				change_variable = { which = strengthen_religion value = 1 }
+			}
+		}
 		if = {
 			limit = {
 				is_heretic = no
@@ -307,12 +389,16 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		location = {
 			any_province_character = {
+				ai = yes
 				is_adult = yes
 				NOT = { character = ROOT }
 				NOT = { is_liege_of = ROOT }
@@ -334,37 +420,16 @@ character_event = {
 		months = 120
 	
 		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
 			factor = 0.75
-			learning = 10
+			has_religion_feature = religion_proselytizing
 		}
 		modifier = {
-			factor = 0.75
-			learning = 11
+			factor = 2.75
+			has_religion_feature = religion_cosmopolitan
 		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+
+		job_event_mtth_modifier_learning_score = yes
+
 		modifier = {
 			factor = 2.0
 			NOT = { religion_authority = 0.4 }
@@ -394,6 +459,7 @@ character_event = {
 		location = {
 			random_province_character = {
 				limit = {
+					ai = yes
 					is_adult = yes
 					NOT = { character = ROOT }
 					NOT = { is_liege_of = ROOT }
@@ -434,6 +500,8 @@ letter_event = {
 		
 		religion = FROM
 		
+		save_event_target_as = portrait_target
+		
 		if = {
 			limit = { higher_tier_than = BARON }
 			religion_authority = {
@@ -471,6 +539,7 @@ letter_event = {
 	
 	option = {
 		name = "EVTOPTA20011"
+		show_portrait = event_target:portrait_target
 	}
 }
 
@@ -485,10 +554,12 @@ letter_event = {
 	option = {
 		name = "EVTOPTA20012"
 		trigger = { FROM = { religion = ROOT } }
+		show_portrait = event_target:portrait_target
 	}
 	option = {
 		name = "EVTOPTB20012"
 		trigger = { FROM = { NOT = { religion = ROOT } } }
+		show_portrait = event_target:portrait_target
 	}
 }
 
@@ -504,10 +575,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		location = {
 			NOT = { religion = ROOT }
 			owner = { same_realm = ROOT }
@@ -524,39 +598,38 @@ character_event = {
 				ai = yes
 			}
 		}
+		modifier = {
+			factor = 1.5
+			liege = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_better_inquisition
+					bloodline_is_active_for = PREV
+				}
+			}
+		}
+		modifier = {
+			factor = 1.5
+			#If chaplain is also your relative.
+			any_owned_bloodline = {
+				has_bloodline_flag = bloodline_better_inquisition
+				bloodline_is_active_for = PREV
+			}
+		}
+		modifier = {
+			factor = 0.75
+			has_religion_feature = religion_dogmatic
+		}
+		modifier = {
+			factor = 1.25
+			has_religion_feature = religion_proselytizing
+		}
+		modifier = {
+			factor = 2.75
+			has_religion_feature = religion_cosmopolitan
+		}
 	
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 1.25
-			learning = 10
-		}
-		modifier = {
-			factor = 1.25
-			learning = 11
-		}
-		modifier = {
-			factor = 1.25
-			learning = 12
-		}
-		modifier = {
-			factor = 1.25
-			learning = 13
-		}
+		job_event_mtth_modifier_inverted_learning_score = yes
+
 		modifier = {
 			factor = 0.75
 			NOT = { religion_authority = 0.4 }
@@ -632,7 +705,7 @@ character_event = {
 				trait = wroth
 			}
 		}
-		inflict_minor_injury_effect = yes
+		add_trait = wounded
 		liege = { letter_event = { id = 20022 tooltip = "EVTTOOLTIP20022" } }
 	}
 	option = {
@@ -642,8 +715,8 @@ character_event = {
 			trait = wroth
 			NOT = { trait = humble}
 		}
-		inflict_minor_injury_effect = yes
-		add_trait = radical
+		add_trait = wounded
+		add_trait = zealous
 		liege = { letter_event = { id = 20022 tooltip = "EVTTOOLTIP20022" } }
 	}
 	option = {
@@ -657,7 +730,7 @@ character_event = {
 				}
 			}
 		}
-		inflict_minor_injury_effect = yes
+		add_trait = wounded
 		liege = { letter_event = { id = 20022 tooltip = "EVTTOOLTIP20022" } }
 	}
 }
@@ -709,16 +782,20 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
+		NOT = { has_religion_feature = religion_cosmopolitan }
 		NOT = { religion_group = pagan_group }
 		NOT = { religion_group = indian_group }
-		trait = radical
+		trait = zealous
 		location = {
 			any_province_lord = {
-				trait = pragmatic
+				trait = cynical
 				NOT = { is_liege_of = ROOT }
 				NOT = { has_character_flag = no_heretic }
 				NOT = { has_character_flag = branded_heretic }
@@ -736,37 +813,11 @@ character_event = {
 		months = 240
 	
 		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
+			factor = 1.5
+			has_religion_feature = religion_dogmatic
 		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+		job_event_mtth_modifier_learning_score = yes
+
 		modifier = {
 			factor = 2.0
 			NOT = { religion_authority = 0.4 }
@@ -789,7 +840,7 @@ character_event = {
 		location = {
 			random_province_lord = {
 				limit = {
-					trait = pragmatic
+					trait = cynical
 					NOT = { is_liege_of = ROOT }
 					NOT = { has_character_flag = no_heretic }
 					NOT = { has_character_flag = branded_heretic }
@@ -1005,10 +1056,14 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
+		NOT = { has_religion_feature = religion_cosmopolitan }
 		location = {
 			NOT = { religion = ROOT }
 			NOT = { has_province_modifier = religious_tension }
@@ -1018,37 +1073,11 @@ character_event = {
 	mean_time_to_happen = {
 		months = 240
 	
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 5 }
-		}
+		job_event_mtth_modifier_inverted_learning_score = yes
+
 		modifier = {
 			factor = 1.25
-			learning = 10
-		}
-		modifier = {
-			factor = 1.25
-			learning = 11
-		}
-		modifier = {
-			factor = 1.25
-			learning = 12
-		}
-		modifier = {
-			factor = 1.25
-			learning = 13
+			has_religion_feature = religion_dogmatic
 		}
 		modifier = {
 			factor = 0.75
@@ -1156,10 +1185,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		NOT = { has_character_flag = preacher_arrives }
 		location = {
 			owner = {
@@ -1168,6 +1200,8 @@ character_event = {
 				NOT = { religion = ROOT }
 				religion_group = pagan_group
 				NOT = { same_realm = ROOT }
+				NOT = { has_character_flag = flag_converting_baptism }
+				NOT = { has_character_modifier = baptism_request_cooldown }
 				controls_religion = no
 			}
 		}
@@ -1199,10 +1233,13 @@ character_event = {
 	capable_only = yes
 	prisoner = no
 	has_character_flag = preacher_arrives
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		location = {
 			owner = {
 				is_adult = yes
@@ -1214,6 +1251,8 @@ character_event = {
 				is_reformed_religion = no
 				NOT = { same_realm = ROOT }
 				controls_religion = no
+				NOT = { has_character_flag = flag_converting_baptism }
+				NOT = { has_character_modifier = baptism_request_cooldown }
 				# at_location = ROOT
 			}
 		}
@@ -1221,38 +1260,12 @@ character_event = {
 	
 	mean_time_to_happen = {
 		months = 120
+
+		job_event_mtth_modifier_learning_score = yes
 	
 		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
+			factor = 1.5
+			has_religion_feature = religion_proselytizing
 		}
 		modifier = {
 			factor = 2.0
@@ -1328,10 +1341,13 @@ character_event = {
 	capable_only = yes
 	prisoner = no
 	has_character_flag = preacher_arrives
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		location = {
 			owner = {
 				NOT = { character = ROOT }
@@ -1347,37 +1363,11 @@ character_event = {
 	mean_time_to_happen = {
 		months = 120
 	
+		job_event_mtth_modifier_learning_score = yes
+
 		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
+			factor = 1.5
+			has_religion_feature = religion_proselytizing
 		}
 		modifier = {
 			factor = 2.0
@@ -1430,10 +1420,13 @@ character_event = {
 	capable_only = yes
 	prisoner = no
 	has_character_flag = preacher_arrives
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_inquisition
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		location = {
 			owner = {
 				NOT = { character = ROOT }
@@ -1527,10 +1520,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_improve_rel_relations
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		location = { 
 			any_province_lord = {
 				NOT = { character = ROOT }
@@ -1544,38 +1540,8 @@ character_event = {
 	mean_time_to_happen = { 
 		months = 240
 		
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+		job_event_mtth_modifier_learning_score = yes
+
 		modifier = {
 			factor = 2.0
 			NOT = { religion_authority = 0.4 }
@@ -1664,10 +1630,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_improve_rel_relations
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		NOT = { religion_group = indian_group }
 		religion_head = {
 			NOT = { character = liege }
@@ -1688,39 +1657,7 @@ character_event = {
 	
 	mean_time_to_happen = {
 		months = 240
-		
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+		job_event_mtth_modifier_learning_score = yes
 	}
 	
 	option = {
@@ -1804,10 +1741,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_advance_cul_tech
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 	}
 	
 	mean_time_to_happen = {
@@ -1821,36 +1761,32 @@ character_event = {
 			}
 		}
 		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
+			factor = 2
+			has_religion_feature = religion_dogmatic
 		}
 		modifier = {
 			factor = 0.75
-			learning = 10
+			has_religion_feature = religion_cosmopolitan
+		}
+
+		job_event_mtth_modifier_learning_score = yes
+
+		modifier = {
+			factor = 0.5
+			liege = {
+				any_owned_bloodline = {
+					has_bloodline_flag = bloodline_more_philosophers
+					bloodline_is_active_for = PREV
+				}
+			}
 		}
 		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
+			factor = 0.5
+			#If chaplain is also your relative.
+			any_owned_bloodline = {
+				has_bloodline_flag = bloodline_more_philosophers
+				bloodline_is_active_for = PREV
+			}
 		}
 	}
 	
@@ -1905,11 +1841,15 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_advance_cul_tech
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		NOT = { religion_group = indian_group }
+		NOT = { has_religion_feature = religion_cosmopolitan }
 		is_heretic = no
 		has_secret_religion = no
 		OR = {
@@ -1934,37 +1874,11 @@ character_event = {
 		months = 1000
 		
 		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
+			factor = 2
+			has_religion_feature = religion_dogmatic
 		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+
+		job_event_mtth_modifier_learning_score = yes
 	}
 	
 	option = {
@@ -2025,15 +1939,40 @@ letter_event = {
 		religion = FROM
 		set_secret_religion = { target_type = true target = FROM }
 		hidden_tooltip = {
-			liege = { letter_event = { id = 20271 } }
+			liege = { letter_event = { id = 20272 } }
 		}
-		
 		ai_chance = { factor = 10 }
 	}
 	option = {
 		name = EVTOPTB20271
-		
+		hidden_tooltip = {
+			liege = { letter_event = { id = 20273 } }
+		}
 		ai_chance = { factor = 5 }
+	}
+}
+
+letter_event = {
+	id = 20272
+	desc = EVTDESC20272
+	border = GFX_event_letter_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA20272
+	}
+}
+
+letter_event = {
+	id = 20273
+	desc = EVTDESC20273
+	border = GFX_event_letter_frame_religion
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = EVTOPTA20273
 	}
 }
 
@@ -2053,10 +1992,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_charity
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		location = { 
 			any_province_lord = {
 				religion = ROOT
@@ -2068,38 +2010,8 @@ character_event = {
 	mean_time_to_happen = { 
 		months = 220
 		
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+		job_event_mtth_modifier_learning_score = yes
+
 		modifier = {
 			factor = 2.0
 			NOT = { religion_authority = 0.4 }
@@ -2187,10 +2099,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_charity
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		location = {
 			religion = ROOT
 			owner = { same_realm = ROOT }
@@ -2200,38 +2115,8 @@ character_event = {
 	mean_time_to_happen = {
 		months = 120
 	
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 0.75
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 1.25
-			learning = 10
-		}
-		modifier = {
-			factor = 1.25
-			learning = 11
-		}
-		modifier = {
-			factor = 1.25
-			learning = 12
-		}
-		modifier = {
-			factor = 1.25
-			learning = 13
-		}
+		job_event_mtth_modifier_inverted_learning_score = yes
+
 		modifier = {
 			factor = 0.75
 			NOT = { religion_authority = 0.4 }
@@ -2293,7 +2178,7 @@ character_event = {
 	
 	option = {
 		name = "EVTOPTA20045"
-		inflict_minor_injury_effect = yes
+		add_trait = wounded
 		hidden_tooltip = {
 			liege = { character_event = { id = 20046 days = 7 } }
 		}
@@ -2330,7 +2215,7 @@ character_event = {
 	}
 }
 
-# 20048: The Mufti pockets money meant for the pooor 
+# 20048: The Mufti pockets money meant for the poor 
 character_event = {
 	id = 20048
 	desc = "EVTDESC20048"
@@ -2341,10 +2226,13 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_charity
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 	}
 	
 	mean_time_to_happen = {
@@ -2415,47 +2303,19 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_charity
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 	}
 	
 	mean_time_to_happen = {
 		months = 180
-		
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+
+		job_event_mtth_modifier_learning_score = yes
 	}
 	
 	option = {
@@ -2495,11 +2355,18 @@ character_event = {
 	min_age = 16
 	capable_only = yes
 	prisoner = no
+	has_job_title = yes
 	
 	trigger = {
 		has_job_action = action_build_zeal
 		NOT = { has_character_modifier = in_seclusion }
+		NOT = { has_character_modifier = bedridden_illness }
+		NOT = { trait = incapable }
 		liege = {
+			OR = { # The AI pretty much always just let their warriors stand around, getting a piety hit when they disband
+				war = yes
+				ai = no
+			}
 			is_adult = yes
 			prisoner = no
 			piety = 10
@@ -2513,6 +2380,7 @@ character_event = {
 				any_war = {
 					OR = {
 						using_cb = crusade
+						using_cb = new_crusade
 						using_cb = religious
 						using_cb = religious_revolt
 						using_cb = pagan_holy_war
@@ -2545,42 +2413,8 @@ character_event = {
 			}
 		}
 		
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 2 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 3 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 4 }
-		}
-		modifier = {
-			factor = 1.25
-			NOT = { learning = 5 }
-		}
-		modifier = {
-			factor = 0.75
-			learning = 9
-		}
-		modifier = {
-			factor = 0.75
-			learning = 10
-		}
-		modifier = {
-			factor = 0.75
-			learning = 11
-		}
-		modifier = {
-			factor = 0.75
-			learning = 12
-		}
-		modifier = {
-			factor = 0.75
-			learning = 13
-		}
+		job_event_mtth_modifier_learning_score = yes
+
 	}
 	
 	option = {
@@ -2678,16 +2512,21 @@ character_event = {
 	trigger = {
 		has_earmarked_regiments = tribal_build_zeal
 		
-		NOT = {
+		NOR = {
 			any_war = {
-				OR = {
-					using_cb = crusade
-					using_cb = religious
-					using_cb = religious_revolt
-					using_cb = pagan_holy_war
-					using_cb = buddhist_holy_war
-					using_cb = muslim_invasion
-					using_cb = manifest_destiny_invasion
+				defender = { character = ROOT }
+				attacker = {
+					NOT = {
+						religion = ROOT
+					}		
+				}
+			}
+			any_war = {
+				attacker = { character = ROOT }
+				defender = {
+					NOT = {
+						religion = ROOT
+					}				
 				}
 			}
 		}

--- a/confederation at crisis/interface/crisis_event_pictures.gfx
+++ b/confederation at crisis/interface/crisis_event_pictures.gfx
@@ -128,7 +128,12 @@ spriteTypes =
 		name = "GFX_evt_illness"
 		texturefile = "gfx\\event_pictures\\city.dds"
 		allwaystransparent = yes
-	}		
+	}
+	spriteType = {
+		name = "GFX_evt_govplaceholder"
+		texturefile = "gfx\\event_pictures\\stone_church.dds"
+		allwaystransparent = yes
+	}
 }
 
 

--- a/confederation at crisis/localisation/crisis_employment_decisions.csv
+++ b/confederation at crisis/localisation/crisis_employment_decisions.csv
@@ -1,5 +1,7 @@
 #CODE;ENGLISH;FRENCH;GERMAN;;SPANISH;;;;;;;;;x
 TOOLTIP_EMPLOYMENT_COOLDOWN_EXPIRED;Has not hired any new courtiers in the last 180 days.;;;;;;;;;;;;;x
+toggle_employment;Toggle Employment Decisions;;;;;;;;;;;;;x
+toggle_employment_desc;Toggles visibility for employment decisions.;;;;;;;;;;;;;x
 employ_diplomat_decision;Hire Diplomat;;;;;;;;;;;;;x
 employ_diplomat_decision_desc;Hire an experienced diplomat to serve you as an advisor.;;;;;;;;;;;;;x
 employ_commander_decision;Hire Commander;;;;;;;;;;;;;x

--- a/confederation at crisis/localisation/crisis_government_flavor.csv
+++ b/confederation at crisis/localisation/crisis_government_flavor.csv
@@ -22,3 +22,4 @@ gov_nnabs_corporate_monarchy;corporate monarchy;;;;;;;;;;;;;x
 gov_military_command_flavor;Military Command;;;;;;;;;;;;;x
 gov_merchant_republic_government_flavor;Corporation Republic;;;;;;;;;;;;;x
 gov_colonial_government_flavor;Colonial State;;;;;;;;;;;;;x
+gov_terran_megacorp;Terran Megacorporation;;;;;;;;;;;;;x


### PR DESCRIPTION
I've been stalling on major additions so I'm bundling all the minor changes together and putting them out now.
- Removed duplicate lifestyle and redundant leadership traits. 
- Blockade Leader in particular was merged with Siege/Planetary Assault Leader since they're functionally the same trait.
- Radical and Moderate (the trait formerly known as Pragmatic) have had their modifiers to zeal increased to match vanilla Zealous and Cynical. + and - 30 were too easily overridden by other traits, which would lead to odd AI behaviour in the future.
- Fixed injury stacking. I think.
- Replaced the current and very outdated job_lord_spiritual with the latest vanilla version. A test to see if it makes council province conversion actually happen.
- Current government flavour names now all refer to an event picture that actually exists. This corrects a minor visual error that would occur when playing Tarka or Strugatsky.
- The Terran Megacorps now have a special government flavour name.
- Employment decisions now have a menu